### PR TITLE
Fix concurrency check

### DIFF
--- a/check.go
+++ b/check.go
@@ -564,7 +564,7 @@ func newSuiteRunner(suite interface{}, runConf *RunConf, concurrent bool, bucket
 	if conf.Benchmark {
 		conf.Verbose = true
 	}
-	if concurrent && conf.ConcurrencyLevel == 0 {
+	if conf.ConcurrencyLevel < 1 {
 		conf.ConcurrencyLevel = 1
 	}
 


### PR DESCRIPTION
If `ConcurrencyLevel` is not >= 1, there will be no tokens in the bucket for concurrent tests, so they will not run.
