### PR TITLE
Output changes

### DIFF
--- a/check.go
+++ b/check.go
@@ -984,6 +984,6 @@ func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
 
 func renderCallHeader(label string, c *C, prefix, suffix string) string {
 	pc := c.method.PC()
-	return fmt.Sprintf("%s%s: %s: %s%s", prefix, label, niceFuncPath(pc),
+	return fmt.Sprintf("%s%s %s: %s: %s%s", prefix, time.Now().Format("15:04:05.000"), label, niceFuncPath(pc),
 		niceFuncName(pc), suffix)
 }

--- a/check.go
+++ b/check.go
@@ -932,12 +932,10 @@ func (ow *outputWriter) Write(content []byte) (n int, err error) {
 }
 
 func (ow *outputWriter) WriteCallStarted(label string, c *C) {
-	if ow.Stream {
-		header := renderCallHeader(label, c, "", "\n")
-		ow.m.Lock()
-		ow.writer.Write([]byte(header))
-		ow.m.Unlock()
-	}
+	header := renderCallHeader(label, c, "", "\n")
+	ow.m.Lock()
+	ow.writer.Write([]byte(header))
+	ow.m.Unlock()
 }
 
 func (ow *outputWriter) WriteCallProblem(label string, c *C) {


### PR DESCRIPTION
Always log the start of tests and prefix current time to test status output:

```
19:57:57.208 START: test_cli.go:439: CLISuite.TestLog
19:57:57.209 START: test_cli.go:446: CLISuite.TestLogFilter
19:57:57.209 START: test_cli.go:505: CLISuite.TestLogFollow
19:57:57.209 START: test_cli.go:479: CLISuite.TestLogStderr
19:58:00.370 PASS: test_cli.go:439: CLISuite.TestLog    3.162s
19:58:01.733 PASS: test_cli.go:479: CLISuite.TestLogStderr      4.524s
19:58:04.774 PASS: test_cli.go:505: CLISuite.TestLogFollow      7.566s
19:58:12.627 PASS: test_cli.go:446: CLISuite.TestLogFilter      15.419s
19:58:12.627 START: <autogenerated>:21: CLISuite.TearDownSuite
OK: 4 passed
```
